### PR TITLE
fix: uptime worker pg connection closed before inserts

### DIFF
--- a/gateway/lua/uptime_worker.lua
+++ b/gateway/lua/uptime_worker.lua
@@ -71,7 +71,7 @@ function _M.check()
         if res then
             pg_status = "operational"
         end
-        pg:keepalive(10000, 10)
+        -- Don't keepalive here: we reuse this connection for inserts below
     else
         log.warn("uptime_worker", "PostgreSQL connect failed", { error = pg_err })
     end


### PR DESCRIPTION
## Summary
- Fix bug where `pg:keepalive()` was called after the PostgreSQL health check, returning the connection to the pool before the worker could use it to insert uptime records
- This caused `"receive_message: failed to get type: closed"` errors on every 5-min check cycle, breaking all uptime tracking since Feb 17

## Root cause
`uptime_worker.lua` reuses the same pgmoon connection for both the PostgreSQL health check and the subsequent INSERT queries. After the health check, it called `pg:keepalive()` which released the connection back to the pool. The later INSERTs then failed because the socket was closed.

## Fix
Defer `keepalive()` — remove the premature call after the health check so the connection stays open for the inserts. It gets returned to the pool at the end of the function (line 141).

## Test plan
- [x] `docker compose up -d --build taguato-gateway`
- [x] Wait 15s, verify new `uptime_checks` records appear with today's date
- [x] No more `"insert failed"` errors in gateway logs
- [x] `/api/status` shows all 4 services as `operational`

🤖 Generated with [Claude Code](https://claude.com/claude-code)