### PR TITLE
fix: empty array serialization in templates and admin endpoints

### DIFF
--- a/gateway/lua/admin.lua
+++ b/gateway/lua/admin.lua
@@ -3,8 +3,17 @@
 
 local db = require "init"
 local json = require "json"
+local cjson = require "cjson"
 local validate = require "validate"
 local session_auth = require "session_auth"
+
+local empty_array_mt = cjson.empty_array_mt
+local function as_array(t)
+    if t == nil or (type(t) == "table" and #t == 0) then
+        return setmetatable({}, empty_array_mt)
+    end
+    return t
+end
 
 -- Verify admin role
 local user = ngx.ctx.user
@@ -196,7 +205,7 @@ if method == "GET" and uri == "/admin/users" then
     end
 
     json.respond(200, {
-        users = res,
+        users = as_array(res),
         total = total,
         page = page,
         limit = limit,

--- a/gateway/lua/templates.lua
+++ b/gateway/lua/templates.lua
@@ -3,7 +3,16 @@
 
 local db = require "init"
 local json = require "json"
+local cjson = require "cjson"
 local validate = require "validate"
+
+local empty_array_mt = cjson.empty_array_mt
+local function as_array(t)
+    if t == nil or (type(t) == "table" and #t == 0) then
+        return setmetatable({}, empty_array_mt)
+    end
+    return t
+end
 
 local user = ngx.ctx.user
 if not user then
@@ -45,7 +54,7 @@ if method == "GET" and uri == "/api/templates" then
     end
 
     json.respond(200, {
-        templates = res,
+        templates = as_array(res),
         total = total,
         page = page,
         limit = limit,


### PR DESCRIPTION
## Summary
- Fixed `cachedTemplates.forEach is not a function` error when navigating between panel sections
- Added `as_array()` wrapper to `templates.lua` and `admin.lua` list endpoints

## Root cause
When a user has 0 templates (or admin searches for users with 0 results), pgmoon returns an empty Lua table `{}`. `cjson.encode({})` serializes this as `{}` (JSON object) instead of `[]` (JSON array). In JavaScript, `{}.forEach` is not a function, causing the console error.

All 13 other list endpoints already used `as_array()` with `cjson.empty_array_mt` — these 2 were missed.

## Files changed
| File | Change |
|------|--------|
| `gateway/lua/templates.lua` | Added `as_array()` wrapper for `templates` field |
| `gateway/lua/admin.lua` | Added `as_array()` wrapper for `users` field |

## Test plan
- [x] 274/274 tests pass locally
- [ ] CI passes
- [ ] Open panel → navigate Dashboard → Messages (no console errors)
- [ ] Open panel → navigate to Scheduled (no console errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)