### PR TITLE
fix: resolve 4 security/bug issues (#35, #36, #37, #38)

### DIFF
--- a/db/init.sql
+++ b/db/init.sql
@@ -305,7 +305,7 @@ CREATE TABLE IF NOT EXISTS taguato.password_resets (
     user_id INT NOT NULL REFERENCES taguato.users(id) ON DELETE CASCADE,
     reset_code VARCHAR(6) NOT NULL,
     reset_token VARCHAR(64),
-    method VARCHAR(10) DEFAULT 'email' CHECK (method IN ('email', 'whatsapp')),
+    method VARCHAR(20) DEFAULT 'email' CHECK (method IN ('email', 'whatsapp', 'admin_email')),
     attempts INT DEFAULT 0,
     expires_at TIMESTAMP NOT NULL DEFAULT (NOW() + INTERVAL '15 minutes'),
     used_at TIMESTAMP,

--- a/gateway/lua/migrations_list.lua
+++ b/gateway/lua/migrations_list.lua
@@ -124,4 +124,14 @@ return {
                 ON taguato.sessions(token_hash, is_active, expires_at) WHERE is_active = true;
         ]],
     },
+    {
+        version = 10,
+        name = "password_resets_allow_admin_email",
+        sql = [[
+            ALTER TABLE taguato.password_resets DROP CONSTRAINT IF EXISTS password_resets_method_check;
+            ALTER TABLE taguato.password_resets ALTER COLUMN method TYPE VARCHAR(20);
+            ALTER TABLE taguato.password_resets ADD CONSTRAINT password_resets_method_check
+                CHECK (method IN ('email', 'whatsapp', 'admin_email'));
+        ]],
+    },
 }

--- a/gateway/lua/rate_limit.lua
+++ b/gateway/lua/rate_limit.lua
@@ -11,7 +11,7 @@ local function check_shared_dict(user_id, limit)
     end
 
     local key = "rl:" .. user_id
-    local newval, err = dict:incr(key, 1, 0, 1)
+    local newval, err = dict:incr(key, 1, 0, 60)
     if not newval then
         ngx.log(ngx.WARN, "rate_limit: shared dict incr failed: ", err)
         return true
@@ -41,7 +41,7 @@ function _M.check(user_id, limit)
         end
         return current
     ]]
-    local current, err = red:eval(script, 1, key, 1)
+    local current, err = red:eval(script, 1, key, 60)
     if not current then
         red:set_keepalive(10000, 10)
         ngx.log(ngx.WARN, "rate_limit: redis eval failed, using shared dict fallback: ", err)


### PR DESCRIPTION
## Summary

Fixes 4 security and bug issues, closes 2 more as won't fix.

### #37 — admin_email CHECK constraint violation (HIGH)
- **Bug**: `admin.lua` inserts `method='admin_email'` into `password_resets`, but the CHECK constraint only allows `'email'` and `'whatsapp'` → error 500 on admin password reset
- **Fix**: Added `'admin_email'` to the CHECK constraint in `init.sql` (new installs) and migration v10 (existing DBs)

### #38 — Rate limit window 1s instead of 60s (HIGH)
- **Bug**: `rate_limit.lua` used TTL=1 second for both Redis and shared dict, making `rate_limit=60` effectively 60 req/sec (3600 req/min) instead of 60 req/min
- **Fix**: Changed TTL from `1` to `60` in both Redis eval and shared dict incr

### #35 — Command injection in alerting.lua (LOW)
- **Risk**: `io.popen` with inline JSON could allow shell injection if payload contained metacharacters
- **Fix**: Write JSON to temp file, pass to curl via `-d @tmpfile`. Added http/https URL scheme validation. Temp file is always cleaned up.

### #36 — Timing attack in recovery code verification (LOW)
- **Risk**: Direct `~=` comparison leaks timing information about matching characters
- **Fix**: Added `constant_time_compare()` using XOR byte comparison (via LuaJIT `bit` library)

### Closed as won't fix
- **#39** (race condition): Rate limit of 3/hour makes concurrent code generation impractical
- **#40** (SSRF in ALERT_WEBHOOK_URL): Admin-only env var; if attacker has `.env` access, they own everything

## Files changed
| File | Change |
|------|--------|
| `db/init.sql` | CHECK constraint: added `'admin_email'`, widened column to VARCHAR(20) |
| `gateway/lua/migrations_list.lua` | Added migration v10: ALTER CHECK constraint for existing DBs |
| `gateway/lua/rate_limit.lua` | TTL `1` → `60` in Redis eval and shared dict |
| `gateway/lua/alerting.lua` | Replaced inline JSON with `@tmpfile` + URL scheme validation |
| `gateway/lua/recovery.lua` | Added `constant_time_compare()` for code verification |

## Test plan
- [x] 274/274 tests pass locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)